### PR TITLE
Reduce memory use

### DIFF
--- a/recogym/envs/abstract.py
+++ b/recogym/envs/abstract.py
@@ -215,7 +215,6 @@ class AbstractEnv(gym.Env, ABC):
                     'u': observation.context().user(),
                     'a': int(self.rng.choice(self.config.num_products)),
                     'ps': 1.0 / self.config.num_products,
-                    'ps-a': np.ones(self.config.num_products) / self.config.num_products,
                 }
 
         observation, reward, done, info = self.step(action['a'] if action is not None else None)

--- a/recogym/envs/abstract.py
+++ b/recogym/envs/abstract.py
@@ -237,7 +237,6 @@ class AbstractEnv(gym.Env, ABC):
             'a': [],
             'c': [],
             'ps': [],
-            'ps-a': [],
         }
         for user_id in range(num_offline_users):
             self.reset(user_id)
@@ -256,7 +255,6 @@ class AbstractEnv(gym.Env, ABC):
                     data['a'].append(None)
                     data['c'].append(None)
                     data['ps'].append(None)
-                    data['ps-a'].append(None)
 
                 action, observation, reward, done, info = self.step_offline(observation, reward, done)
 
@@ -267,7 +265,6 @@ class AbstractEnv(gym.Env, ABC):
                 data['a'].append(action['a'])
                 data['c'].append(reward)
                 data['ps'].append(action['ps'])
-                data['ps-a'].append(action['ps-a'])
 
                 if done:
                     break


### PR DESCRIPTION
ps-a is memory hungry but it is also used for offline evaluation functions - this is a relatively small use case though... can we make it optional?

(tensorflow3) (base) ➜  reco-gym git:(reduce_memory_use) find . -name “*.py” -print | xargs grep “ps-a”
./recogym/evaluate_agent.py:                prob_policy = agent.act(Observation(DefaultContext(t[jj],u), session), 0, False)[‘ps-a’]
./recogym/evaluate_agent.py:                prob_policy = agent.act(Observation(DefaultContext(t[jj],u), session), 0, False)[‘ps-a’]
./recogym/evaluate_agent.py:                prob_policy = agent.act(Observation(DefaultContext(t[jj],u), session), 0, False)[‘ps-a’]
./recogym/agents/abstract.py:            self.data[‘ps-a’].append(None)
./recogym/agents/abstract.py:            self.data[‘ps-a’].append(action[‘ps-a’] if ‘ps-a’ in action else None)
./recogym/agents/abstract.py:            ‘ps-a’: [],
./recogym/agents/random_agent.py:                ‘ps-a’: np.ones(self.config.num_products) / self.config.num_products,
./recogym/agents/nn_ips.py:                        ‘ps-a’: ps_all,
./recogym/agents/organic_mf.py:                ‘ps-a’: all_ps,
./recogym/agents/bandit_mf.py:                ‘ps-a’: all_ps,
./recogym/agents/organic_user_count.py:                        ‘ps-a’: ps_all,
./recogym/agents/epsilon_greedy.py:                product_probas = greedy_action[‘ps-a’]
./recogym/agents/epsilon_greedy.py:                    ‘ps-a’: self.config.epsilon * product_probas,
./recogym/agents/epsilon_greedy.py:                ‘ps-a’: (1.0 - self.config.epsilon) * greedy_action[‘ps-a’],
./recogym/agents/logreg_poly.py:                        ‘ps-a’: ps_all,
./recogym/agents/bandit_count.py:                ‘ps-a’: ps_all,
./recogym/agents/organic_count.py:                ‘ps-a’: ps_all,
./recogym/agents/logreg_ips.py:                        ‘ps-a’: all_ps,

:disappointed:
the new function evaluate_IPS uses it..   I would be a bit sorry to break it.. but it is only that which is affected..
we could either stay below 10000 …  break it..  or make it optional…